### PR TITLE
Update heal/feed commands and upgrade vakanicore version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 vpaper-api = "1.19.4-R0.1-SNAPSHOT"
 vfawe-bom = "1.42"
 vluckperms = "5.4"
-vakanicore = "1.1.7"
+vakanicore = "1.1.9"
 cloudcommands = "2.0.0-beta.2"
 acf = "0.5.1-SNAPSHOT"
 # Libraries
@@ -29,10 +29,10 @@ luckperms = { group = "net.luckperms", name = "api", version.ref = "vluckperms" 
 hikaricp = { group = "com.zaxxer", name = "HikariCP", version = "5.1.0" }
 akanicore = { group = "it.einjojo.akani.core", name = "paper", version.ref = "vakanicore" }
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version = "3.1.8" }
-cloudcore = { group = "org.incendo", name = "cloud-core", version.ref="cloudcommands"}
-cloudannotations = { group = "org.incendo", name = "cloud-annotations", version.ref="cloudcommands"}
-cloudpaper = { group = "org.incendo", name = "cloud-paper", version.ref="cloudcommands"}
-cloudminecraft = { group = "org.incendo", name = "cloud-minecraft-extras", version.ref="cloudcommands"}
+cloudcore = { group = "org.incendo", name = "cloud-core", version.ref = "cloudcommands" }
+cloudannotations = { group = "org.incendo", name = "cloud-annotations", version.ref = "cloudcommands" }
+cloudpaper = { group = "org.incendo", name = "cloud-paper", version.ref = "cloudcommands" }
+cloudminecraft = { group = "org.incendo", name = "cloud-minecraft-extras", version.ref = "cloudcommands" }
 
 
 [bundles]

--- a/src/main/java/it/einjojo/akani/essentials/command/HealFeedCommand.java
+++ b/src/main/java/it/einjojo/akani/essentials/command/HealFeedCommand.java
@@ -3,10 +3,12 @@ package it.einjojo.akani.essentials.command;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.PaperCommandManager;
 import co.aikar.commands.annotation.*;
+import it.einjojo.akani.core.paper.player.PaperAkaniPlayer;
 import it.einjojo.akani.essentials.AkaniEssentialsPlugin;
 import it.einjojo.akani.essentials.util.MessageKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
 
 public class HealFeedCommand extends BaseCommand {
 
@@ -23,31 +25,46 @@ public class HealFeedCommand extends BaseCommand {
     @CommandAlias("feed")
     @CommandPermission(AkaniEssentialsPlugin.PERMISSION_BASE + "feed")
     @Description("Feed yourself or another player")
-    @CommandCompletion("@players")
-    public void feed(Player sender, @Optional Player target) {
-        if (target == null) {
-            sender.setFoodLevel(20);
-            sender.setSaturation(20);
-            plugin.sendMessage(sender, MessageKey.FEED_SELF);
+    @CommandCompletion("@akaniplayers:includeSender")
+    public void feed(CommandSender sender, @Optional PaperAkaniPlayer targetAkaniPlayer) {
+        if (targetAkaniPlayer == null) {
+            if (sender instanceof Player player) {
+                player.setFoodLevel(20);
+                plugin.sendMessage(sender, MessageKey.FEED_SELF);
+            } else {
+                plugin.sendMessage(sender, MessageKey.GENERIC_ERROR);
+            }
         } else {
-            target.setFoodLevel(20);
-            target.setSaturation(20);
-            plugin.sendMessage(sender, MessageKey.FEED_OTHER, s -> s.replaceAll("%player%", target.getName()));
+            java.util.Optional<Player> target = targetAkaniPlayer.bukkitPlayer();
+            target.ifPresentOrElse(targetPlayer -> {
+                targetPlayer.setFoodLevel(20);
+                plugin.sendMessage(sender, MessageKey.FEED_OTHER, s -> s.replaceAll("%player%", targetPlayer.getName()));
+            }, () -> {
+                plugin.sendMessage(sender, MessageKey.PLAYER_NOT_FOUND);
+            });
         }
     }
 
     @CommandAlias("heal")
     @CommandPermission(AkaniEssentialsPlugin.PERMISSION_BASE + "heal")
     @Description("Heal yourself or another player")
-    @CommandCompletion("@players")
-    public void heal(CommandSender sender, @Optional Player target) {
-        if (target == null) {
-            if (!(sender instanceof Player senderPlayer)) return;
-            senderPlayer.setHealth(20);
-            plugin.sendMessage(sender, MessageKey.HEAL_SELF);
+    @CommandCompletion("@akaniplayers:includeSender")
+    public void heal(CommandSender sender, @Optional PaperAkaniPlayer targetAkaniPlayer) {
+        if (targetAkaniPlayer == null) {
+            if (sender instanceof Player player) {
+                player.setHealth(player.getMaxHealth());
+                plugin.sendMessage(sender, MessageKey.HEAL_SELF);
+            } else {
+                plugin.sendMessage(sender, MessageKey.GENERIC_ERROR);
+            }
         } else {
-            target.setHealth(20);
-            plugin.sendMessage(sender, MessageKey.HEAL_OTHER, s -> s.replaceAll("%player%", target.getName()));
+            java.util.Optional<Player> target = targetAkaniPlayer.bukkitPlayer();
+            target.ifPresentOrElse(targetPlayer -> {
+                targetPlayer.setHealth(targetPlayer.getMaxHealth());
+                plugin.sendMessage(sender, MessageKey.HEAL_OTHER, s -> s.replaceAll("%player%", targetPlayer.getName()));
+            }, () -> {
+                plugin.sendMessage(sender, MessageKey.PLAYER_NOT_FOUND);
+            });
         }
     }
 }


### PR DESCRIPTION
Modified the 'heal' and 'feed' commands in `HealFeedCommand.java` to handle `PaperAkaniPlayer` instances instead of `Player`. This includes better error handling for non-player command senders. Additionally, the version of `vakanicore` library in `libs.versions.toml` was updated from 1.1.7 to 1.1.9.